### PR TITLE
Extend study date range

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,12 +1,12 @@
-# Study start date
+# Study start dated
 # Note: This should match the start dates in project.yaml
 # In QOF also: Payment Period Start Date (PPSD)
-start_date = "2019-03-01"
+start_date = "2019-04-01"
 
 # Study end date
 # Note: This should match the end dates in project.yaml
 # In QOF also: Payment Period End Date (PPED)
-end_date = "2022-10-01"
+end_date = "2023-03-31"
 
 # demographic variables by which code use is broken down
 demographic_breakdowns = [

--- a/project.yaml
+++ b/project.yaml
@@ -20,7 +20,7 @@ actions:
     run: > 
       cohortextractor:latest generate_cohort 
       --study-definition study_definition_bp002 
-      --index-date-range "2019-03-01 to 2022-10-01 by month" 
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
       --output-dir=output
       --output-format=csv
     outputs:


### PR DESCRIPTION
This adds 4 complete NHS financial years:
- 1st April 2019 - 31st March 2020
- 1st April 2020 - 31st March 2021
- 1st April 2021 - 31st March 2022
- 1st April 2022 - 31st March 2023