### PR TITLE
Add 1 year lookback period for BP002 indicator

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,12 +1,12 @@
-# Study start date
+# Study start dated
 # Note: This should match the start dates in project.yaml
 # In QOF also: Payment Period Start Date (PPSD)
-start_date = "2019-03-01"
+start_date = "2019-04-01"
 
 # Study end date
 # Note: This should match the end dates in project.yaml
 # In QOF also: Payment Period End Date (PPED)
-end_date = "2022-10-01"
+end_date = "2023-03-31"
 
 # demographic variables by which code use is broken down
 demographic_breakdowns = [

--- a/analysis/dict_bp_variables.py
+++ b/analysis/dict_bp_variables.py
@@ -10,7 +10,7 @@ from codelists_bp import (
 )
 
 # Define dictionary of variables needed for blood pressure indicator BP002:
-bp002_variables = dict(
+bp002_variables_5y_lookback = dict(
     # Denominator Rule Number 1
     # Description: Reject patients from the specified population who are
     # aged less than 45 years old.
@@ -106,6 +106,136 @@ bp002_variables = dict(
         bp002_denominator_r1 AND
         (NOT bp002_denominator_r2) AND
         bp_dec_5y
+        """
+    ),
+    bp002_denominator_r4_reject=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+        (NOT bp002_denominator_r2) AND
+        bp002_denominator_r3 AND
+        (NOT reg_dat_3m)
+        """
+    ),
+    bp002_denominator=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+            (bp002_denominator_r2 OR
+                (bp002_denominator_r3 AND
+                 bp002_denominator_r4)
+            )
+        """
+    ),
+    bp002_numerator=patients.satisfying(
+        """
+        # Numerator Rule Number 1
+        # NOTE: This is same as Denominator Rule Number 2
+        # Description: Select patients from the denominator who had their
+        # blood pressure recorded in the 5 year period leading up to and
+        # including the payment period end date. Reject the remaining patients.
+        bp002_denominator AND
+        bp002_denominator_r2
+        """
+    ),
+)
+
+# Define dictionary of variables needed for blood pressure indicator BP002
+# with 1 year lookback:
+bp002_variables_1y_lookback = dict(
+    # Denominator Rule Number 1
+    # Description: Reject patients from the specified population who are
+    # aged less than 45 years old.
+    bp002_denominator_r1=patients.satisfying(
+        """
+        age >= 45
+        """
+    ),
+    # Denominator Rule Number 2
+    # NOTE: This is same as Numerator Rule Number 1
+    # Description: Select patients passed to this rule who had their blood
+    # pressure recorded in the *1 year* period leading up to and including
+    # the payment period end date.
+    bp002_denominator_r2=patients.satisfying(
+        """
+        bp_rec_1y
+        """,
+        bp_rec_1y=patients.with_these_clinical_events(
+            codelist=bp_codes,
+            between=[
+                "first_day_of_month(index_date) - 1 year",
+                "last_day_of_month(index_date)",
+            ],
+            returning="binary_flag",
+            return_expectations={"incidence": 0.5},
+        ),
+    ),
+    # Denominator Rule Number 3
+    # Description: Reject patients passed to this rule chose not to have
+    # their blood pressure recorded in the *1 year* period leading up to and
+    # including the payment period end date.
+    bp002_denominator_r3=patients.satisfying(
+        """
+        NOT bp_dec_1y
+        """,
+        bp_dec_1y=patients.with_these_clinical_events(
+            between=[
+                "first_day_of_month(index_date) - 1 year",
+                "last_day_of_month(index_date)",
+            ],
+            codelist=bp_dec_codes,
+            returning="binary_flag",
+        ),
+    ),
+    # Define exclusion variable for denominator rule 3
+    # to be used as numerator in measures
+    bp002_excl_denominator_r3=patients.satisfying(
+        """
+        bp_dec_1y
+        """
+    ),
+    # Denominator Rule Number 4
+    # Description: Reject patients passed to this rule who registered with
+    # the GP practice in the 3 month period leading up to and including
+    # the payment period end date.
+    bp002_denominator_r4=patients.satisfying(
+        """
+        reg_dat_3m
+        """,
+        # NOTE: This variable selects patients that were registered with one
+        # practice in the last 3 months. Therefore, this variable (reg_dat_3m)
+        # specifies the patients that need to be selected for in the
+        # denominator.
+        reg_dat_3m=patients.registered_with_one_practice_between(
+            start_date="index_date - 3 months",
+            end_date="index_date",
+            return_expectations={"incidence": 0.1},
+        ),
+    ),
+    # Define exclusion variable for denominator rule 4
+    # to be used as numerator in measures
+    bp002_excl_denominator_r4=patients.satisfying(
+        """
+        NOT reg_dat_3m
+        """
+    ),
+    # Add flowchart counts for each select / reject rule
+    # NOTE: Some of these variables are coded as "select" variables
+    # and not "reject" as specified in the business rules
+    bp002_denominator_r1_reject=patients.satisfying(
+        """
+        bp002_denominator_r1
+        """
+    ),
+    bp002_denominator_r2_select=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+        bp002_denominator_r2
+        """
+    ),
+    bp002_denominator_r3_reject=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+        (NOT bp002_denominator_r2) AND
+        bp_dec_1y
         """
     ),
     bp002_denominator_r4_reject=patients.satisfying(

--- a/analysis/join_measures.R
+++ b/analysis/join_measures.R
@@ -12,43 +12,42 @@ source(here::here("lib", "funs.R"))
 fs::dir_create(here::here("output", "joined", "measures"))
 
 # Get file names and path ----
-bp002_excl_breakdown_dr3_measures <- fs::dir_ls(
+bp002_1y_achievem_breakdown_measures <- fs::dir_ls(
   path = "output/joined",
-  glob = "*measure_bp002_excl_denominator_r3_*_breakdown_rate.csv$"
+  glob = "*measure_bp002_1y_achievem_*_breakdown_rate.csv$"
 )
 
-bp002_excl_population_dr3_measures <- fs::dir_ls(
+bp002_5y_achievem_breakdown_measures <- fs::dir_ls(
   path = "output/joined",
-  glob = "*measure_bp002_excl_denominator_r3_population_rate.csv$"
-)
-
-bp002_excl_breakdown_dr4_measures <- fs::dir_ls(
-  path = "output/joined",
-  glob = "*measure_bp002_excl_denominator_r4_*_breakdown_rate.csv$"
-)
-
-bp002_excl_population_dr4_measures <- fs::dir_ls(
-  path = "output/joined",
-  glob = "*measure_bp002_excl_denominator_r4_population_rate.csv$"
-)
-
-bp002_achievem_breakdown_measures <- fs::dir_ls(
-  path = "output/joined",
-  glob = "*measure_bp002_achievem_*_breakdown_rate.csv$"
+  glob = "*measure_bp002_5y_achievem_*_breakdown_rate.csv$"
 )
 
 # Remove practice level data from achievement measures
-bp002_achievem_breakdown_measures <- bp002_achievem_breakdown_measures[!stringr::str_detect(bp002_achievem_breakdown_measures, "practice")]
+bp002_1y_achievem_breakdown_measures <- bp002_1y_achievem_breakdown_measures[!stringr::str_detect(bp002_1y_achievem_breakdown_measures, "practice")]
+bp002_5y_achievem_breakdown_measures <- bp002_5y_achievem_breakdown_measures[!stringr::str_detect(bp002_5y_achievem_breakdown_measures, "practice")]
 
-bp002_achievem_population_measures <- fs::dir_ls(
+bp002_1y_achievem_population_measures <- fs::dir_ls(
   path = "output/joined",
-  glob = "*measure_bp002_achievem_population_rate.csv$"
+  glob = "*measure_bp002_1y_achievem_population_rate.csv$"
 )
 
-df_bp002_achievem_population <- read_population_measures(bp002_achievem_population_measures)
-df_bp002_achievem_breakdown <- read_breakdown_measures(bp002_achievem_breakdown_measures)
+bp002_5y_achievem_population_measures <- fs::dir_ls(
+  path = "output/joined",
+  glob = "*measure_bp002_5y_achievem_population_rate.csv$"
+)
 
-df_bp002_achievem <- dplyr::bind_rows(df_bp002_achievem_population, df_bp002_achievem_breakdown)
+# read bp002 1y lookback data
+df_bp002_1y_achievem_population <- read_population_measures(bp002_1y_achievem_population_measures)
+df_bp002_1y_achievem_breakdown <- read_breakdown_measures(bp002_1y_achievem_breakdown_measures)
+df_bp002_1y_achievem <- dplyr::bind_rows(df_bp002_1y_achievem_population, df_bp002_1y_achievem_breakdown) %>%
+  dplyr::mutate(lookback = "1y")
+
+df_bp002_5y_achievem_population <- read_population_measures(bp002_5y_achievem_population_measures)
+df_bp002_5y_achievem_breakdown <- read_breakdown_measures(bp002_5y_achievem_breakdown_measures)
+df_bp002_5y_achievem <- dplyr::bind_rows(df_bp002_5y_achievem_population, df_bp002_5y_achievem_breakdown) %>%
+  dplyr::mutate(lookback = "5y")
+
+df_bp002_achievem <- dplyr::bind_rows(df_bp002_1y_achievem, df_bp002_5y_achievem)
 
 df_bp002_achievem <- df_bp002_achievem %>%
   round_variables(c("bp002_numerator", "bp002_denominator", "population")) %>%
@@ -57,36 +56,4 @@ df_bp002_achievem <- df_bp002_achievem %>%
 readr::write_csv(
   df_bp002_achievem,
   here::here("output", "joined", "measures", "measures_bp002_achievem.csv")
-)
-
-df_bp002_excl_dr3_population <- read_population_measures(bp002_excl_population_dr3_measures) %>%
-  dplyr::mutate(excl_rule = "bp002_denom_r3") %>%
-  dplyr::rename(excl_denominator = bp002_excl_denominator_r3)
-
-df_bp002_excl_dr4_population <- read_population_measures(bp002_excl_population_dr4_measures) %>%
-  dplyr::mutate(excl_rule = "bp002_denom_r4") %>%
-  dplyr::rename(excl_denominator = bp002_excl_denominator_r4)
-
-df_bp002_excl_dr3_breakdown <- read_breakdown_measures(bp002_excl_breakdown_dr3_measures) %>%
-  dplyr::mutate(excl_rule = "bp002_denom_r3") %>%
-  dplyr::rename(excl_denominator = bp002_excl_denominator_r3)
-
-df_bp002_excl_dr4_breakdown <- read_breakdown_measures(bp002_excl_breakdown_dr4_measures) %>%
-  dplyr::mutate(excl_rule = "bp002_denom_r4") %>%
-  dplyr::rename(excl_denominator = bp002_excl_denominator_r4)
-
-df_bp002_excl <- dplyr::bind_rows(
-  df_bp002_excl_dr3_population,
-  df_bp002_excl_dr3_breakdown,
-  df_bp002_excl_dr4_population,
-  df_bp002_excl_dr4_breakdown
-)
-
-df_bp002_excl <- df_bp002_excl %>%
-  round_variables(c("excl_denominator", "population")) %>%
-  dplyr::mutate(value = excl_denominator / population)
-
-readr::write_csv(
-  df_bp002_excl,
-  here::here("output", "joined", "measures", "measures_bp002_excl.csv")
 )

--- a/analysis/study_definition_bp002_1y_lookback.py
+++ b/analysis/study_definition_bp002_1y_lookback.py
@@ -14,7 +14,7 @@ from config import (
 from codelists_bp import bp_codes, bp_dec_codes
 
 # Import shared variable dictionaries
-from dict_bp_variables import bp002_variables
+from dict_bp_variables import bp002_variables_1y_lookback
 from dict_demographic_variables import demographic_variables
 
 study = StudyDefinition(
@@ -40,20 +40,20 @@ study = StudyDefinition(
     ),
     # Include blood pressure and demographic variable dictionaries
     **demographic_variables,
-    **bp002_variables,
+    **bp002_variables_1y_lookback,
 )
 
 # Create blood pressure achievement measures
 measures = [
     Measure(
-        id="bp002_achievem_population_rate",
+        id="bp002_1y_achievem_population_rate",
         numerator="bp002_numerator",
         denominator="bp002_denominator",
         group_by=["population"],
         small_number_suppression=True,
     ),
     Measure(
-        id="bp002_achievem_practice_breakdown_rate",
+        id="bp002_1y_achievem_practice_breakdown_rate",
         numerator="bp002_numerator",
         denominator="bp002_denominator",
         group_by=["practice"],
@@ -62,20 +62,20 @@ measures = [
 ]
 
 # Create blood pressure exclusion measures for total population
-for exclusion in bp002_exclusions:
-    m = Measure(
-        id=f"""bp002_{exclusion.lstrip("bp002_")}_population_rate""",
-        numerator=exclusion,
-        denominator="population",
-        group_by=["population"],
-        small_number_suppression=True,
-    )
-    measures.append(m)
+# for exclusion in bp002_exclusions:
+#     m = Measure(
+#         id=f"""bp002_{exclusion.lstrip("bp002_")}_population_rate""",
+#         numerator=exclusion,
+#         denominator="population",
+#         group_by=["population"],
+#         small_number_suppression=True,
+#     )
+#     measures.append(m)
 
 # Create demographic breakdowns for blood pressure indicator BP002 measures
 for breakdown in demographic_breakdowns:
     m = Measure(
-        id=f"bp002_achievem_{breakdown}_breakdown_rate",
+        id=f"bp002_1y_achievem_{breakdown}_breakdown_rate",
         numerator="bp002_numerator",
         denominator="bp002_denominator",
         group_by=[breakdown],
@@ -84,24 +84,24 @@ for breakdown in demographic_breakdowns:
     measures.append(m)
 
 # Create demographic breakdowns for blood pressure exclusion measures
-for breakdown in demographic_breakdowns:
-    for exclusion in bp002_exclusions:
-        m = Measure(
-            id=f"""bp002_{exclusion.lstrip("bp002_")}_{breakdown}_breakdown_rate""",
-            numerator=exclusion,
-            denominator="population",
-            group_by=[breakdown],
-            small_number_suppression=True,
-        )
-        measures.append(m)
+# for breakdown in demographic_breakdowns:
+#     for exclusion in bp002_exclusions:
+#         m = Measure(
+#             id=f"""bp002_1y{exclusion.lstrip("bp002_")}_{breakdown}_breakdown_rate""",
+#             numerator=exclusion,
+#             denominator="population",
+#             group_by=[breakdown],
+#             small_number_suppression=True,
+#         )
+#         measures.append(m)
 
 # Create bloow pressure flowchart count measures
-for select_reject in bp002_flowchart:
-    m = Measure(
-        id=f"bp002_flow_{select_reject}_population_rate",
-        numerator=f"bp002_{select_reject}",
-        denominator="population",
-        group_by=["population"],
-        small_number_suppression=True,
-    )
-    measures.append(m)
+# for select_reject in bp002_flowchart:
+#     m = Measure(
+#         id=f"bp002_1y_flow_{select_reject}_population_rate",
+#         numerator=f"bp002_{select_reject}",
+#         denominator="population",
+#         group_by=["population"],
+#         small_number_suppression=True,
+#     )
+#     measures.append(m)

--- a/analysis/study_definition_bp002_5y_lookback.py
+++ b/analysis/study_definition_bp002_5y_lookback.py
@@ -1,0 +1,107 @@
+from cohortextractor import StudyDefinition, patients, Measure
+
+import json
+import pandas as pd
+
+# Import dates and codelists
+from config import (
+    start_date,
+    end_date,
+    demographic_breakdowns,
+    bp002_exclusions,
+    bp002_flowchart,
+)
+from codelists_bp import bp_codes, bp_dec_codes
+
+# Import shared variable dictionaries
+from dict_bp_variables import bp002_variables_5y_lookback
+from dict_demographic_variables import demographic_variables
+
+study = StudyDefinition(
+    index_date=start_date,
+    default_expectations={
+        "date": {"earliest": start_date, "latest": end_date},
+        "rate": "uniform",
+        "incidence": 0.5,
+    },
+    population=patients.satisfying(
+        """
+        # Define general population parameters
+        (NOT died) AND
+        (sex = 'F' OR sex = 'M') AND
+        (age_band != 'missing') AND
+
+        # Define GMS registration status
+        gms_reg_status AND
+
+        # Define list size type:
+        age >= 45
+        """,
+    ),
+    # Include blood pressure and demographic variable dictionaries
+    **demographic_variables,
+    **bp002_variables_5y_lookback,
+)
+
+# Create blood pressure achievement measures
+measures = [
+    Measure(
+        id="bp002_5y_achievem_population_rate",
+        numerator="bp002_numerator",
+        denominator="bp002_denominator",
+        group_by=["population"],
+        small_number_suppression=True,
+    ),
+    Measure(
+        id="bp002_5y_achievem_practice_breakdown_rate",
+        numerator="bp002_numerator",
+        denominator="bp002_denominator",
+        group_by=["practice"],
+        small_number_suppression=True,
+    ),
+]
+
+# Create blood pressure exclusion measures for total population
+# for exclusion in bp002_exclusions:
+#     m = Measure(
+#         id=f"""bp002_5y_{exclusion.lstrip("bp002_")}_population_rate""",
+#         numerator=exclusion,
+#         denominator="population",
+#         group_by=["population"],
+#         small_number_suppression=True,
+#     )
+#     measures.append(m)
+
+# Create demographic breakdowns for blood pressure indicator BP002 measures
+for breakdown in demographic_breakdowns:
+    m = Measure(
+        id=f"bp002_5y_achievem_{breakdown}_breakdown_rate",
+        numerator="bp002_numerator",
+        denominator="bp002_denominator",
+        group_by=[breakdown],
+        small_number_suppression=True,
+    )
+    measures.append(m)
+
+# Create demographic breakdowns for blood pressure exclusion measures
+# for breakdown in demographic_breakdowns:
+#     for exclusion in bp002_exclusions:
+#         m = Measure(
+#             id=f"""bp002_5y_{exclusion.lstrip("bp002_")}_{breakdown}_breakdown_rate""",
+#             numerator=exclusion,
+#             denominator="population",
+#             group_by=[breakdown],
+#             small_number_suppression=True,
+#         )
+#         measures.append(m)
+
+# Create bloow pressure flowchart count measures
+# for select_reject in bp002_flowchart:
+#     m = Measure(
+#         id=f"bp002_5y_flow_{select_reject}_population_rate",
+#         numerator=f"bp002_{select_reject}",
+#         denominator="population",
+#         group_by=["population"],
+#         small_number_suppression=True,
+#     )
+#     measures.append(m)

--- a/project.yaml
+++ b/project.yaml
@@ -15,38 +15,59 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/input_ethnicity.csv
-
-  generate_study_population_bp002:
+  
+  generate_study_population_bp002_1y_lookback:
     run: > 
       cohortextractor:latest generate_cohort 
-      --study-definition study_definition_bp002 
+      --study-definition study_definition_bp002_1y_lookback
       --index-date-range "2019-04-01 to 2023-03-31 by month" 
       --output-dir=output
       --output-format=csv
     outputs:
       highly_sensitive:
-        cohort: output/input_bp002*.csv
+        cohort: output/input_bp002_1y*.csv
   
-  join_ethnicity_bp002:
+  generate_study_population_bp002_5y_lookback:
+    run: > 
+      cohortextractor:latest generate_cohort 
+      --study-definition study_definition_bp002_5y_lookback 
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
+      --output-dir=output
+      --output-format=csv
+    outputs:
+      highly_sensitive:
+        cohort: output/input_bp002_5y*.csv
+  
+  join_ethnicity:
     run: >
       cohort-joiner:v0.0.12 
         --lhs output/input_bp002*.csv
         --rhs output/input_ethnicity.csv
         --output-dir output/joined
-    needs: [generate_study_population_ethnicity, generate_study_population_bp002]
+    needs: [generate_study_population_ethnicity, generate_study_population_bp002_1y_lookback, generate_study_population_bp002_5y_lookback]
     outputs:
       highly_sensitive:
         cohort: output/joined/input_bp002*.csv
 
-  generate_measures_bp002:
+  generate_measures_bp002_1y_lookback:
      run: >
        cohortextractor:latest generate_measures 
-       --study-definition study_definition_bp002 
+       --study-definition study_definition_bp002_1y_lookback 
        --output-dir=output/joined
-     needs: [join_ethnicity_bp002]
+     needs: [join_ethnicity]
      outputs:
        moderately_sensitive:
-         measure_csv: output/joined/measure_bp002_*_rate.csv
+         measure_csv: output/joined/measure_bp002_1y*_rate.csv
+
+  generate_measures_bp002_5y_lookback:
+     run: >
+       cohortextractor:latest generate_measures 
+       --study-definition study_definition_bp002_5y_lookback 
+       --output-dir=output/joined
+     needs: [join_ethnicity]
+     outputs:
+       moderately_sensitive:
+         measure_csv: output/joined/measure_bp002_5y*_rate.csv
 
   generate_deciles_charts:
     run: >
@@ -59,7 +80,7 @@ actions:
         output: true
       charts:
         output: true
-    needs: [generate_measures_bp002]
+    needs: [generate_measures_bp002_1y_lookback, generate_measures_bp002_5y_lookback]
     outputs:
       moderately_sensitive:
         deciles_charts: output/joined/deciles_chart_*_*_practice_breakdown_rate.png
@@ -67,8 +88,7 @@ actions:
       
   join_measures:
     run: r:latest analysis/join_measures.R
-    needs: [generate_measures_bp002]
+    needs: [generate_measures_bp002_1y_lookback, generate_measures_bp002_5y_lookback]
     outputs:
       moderately_sensitive:
         bp002_achievement_csv: output/joined/measures/measures_bp002_achievem.csv
-        bp002_exclusion_csv: output/joined/measures/measures_bp002_excl.csv

--- a/project.yaml
+++ b/project.yaml
@@ -20,7 +20,7 @@ actions:
     run: > 
       cohortextractor:latest generate_cohort 
       --study-definition study_definition_bp002 
-      --index-date-range "2019-03-01 to 2022-10-01 by month" 
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
       --output-dir=output
       --output-format=csv
     outputs:


### PR DESCRIPTION
The BP002 is defined with a 5 year lookback period in the QOF business rules.
To detect changes to this indicator within a one year period (the same as hypertension management indicators HYP003 and HYP007) this PR adds a 1 year lookback for the the BP002 indicator.

This PR also includes the extended time range implemented in #50.
